### PR TITLE
Feature 39 update java

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,8 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - develop*
+      - main
+      #- develop
 
 jobs:
   build:

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,9 @@
     <url>http://maven.apache.org</url>
 
     <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <compiler.target.version>1.7</compiler.target.version>
         <spring.version>5.3.22</spring.version>
         <d1_libclient_java.version>2.3.1</d1_libclient_java.version>
         <solr.version>8.11.2</solr.version>
@@ -327,10 +328,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>${compiler.target.version}</target>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>com.mycila.maven-license-plugin</groupId>


### PR DESCRIPTION
This is a simple upgrade of the maven build to use JDK 17, which is the LTS Java release supported through 2027. This branchs tests cleanly for me using the Java 17.0.5 from homebrew:

```
$ mvn -v
Apache Maven 3.8.6 (84538c9988a25aec085021c365c560670ad80f63)
Maven home: /usr/local/Cellar/maven/3.8.6/libexec
Java version: 17.0.5, vendor: Homebrew, runtime: /usr/local/Cellar/openjdk@17/17.0.5/libexec/openjdk.jdk/Contents/Home
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "11.6.6", arch: "x86_64", family: "mac"
```

@taojing2002 please review and if it works for you we can probably merge right into develop.