### PR TITLE
Feature 67 mn base url prop

### DIFF
--- a/helm/config/dataone-indexer.properties
+++ b/helm/config/dataone-indexer.properties
@@ -1,4 +1,4 @@
-index.d1node.baseURL={{ include "idxworker.mn.url" . }}
+dataone.mn.baseURL={{ include "idxworker.mn.url" . }}
 index.data.root.directory={{ .Values.idxworker.data_directory }}
 index.document.root.directory={{ .Values.idxworker.document_directory }}
 index.tdb.directory={{ .Values.idxworker.tripleDbDirectory }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
                 secretKeyRef:
                   name: dataone-token
                   key: DataONEauthToken
-                  # If 'false", the secret must exist before the pod can start
+                  # If 'false', the secret must exist before the pod can start
                   # App versions before v2.3.4 will read this value from a config file, not the env var.
                   optional: true
             - name: RABBITMQ_PASSWORD

--- a/src/main/java/org/dataone/cn/indexer/object/ObjectManager.java
+++ b/src/main/java/org/dataone/cn/indexer/object/ObjectManager.java
@@ -58,7 +58,7 @@ public class ObjectManager {
     private static ObjectManager manager = null;
     private static String dataRootDir = Settings.getConfiguration().getString("index.data.root.directory");
     private static String documentRootDir = Settings.getConfiguration().getString("index.document.root.directory");
-    private static String nodeBaseURL = Settings.getConfiguration().getString("index.d1node.baseURL");
+    private static String nodeBaseURL = Settings.getConfiguration().getString("dataone.mn.baseURL");
     private static String DataONEauthToken = null;
     private static Logger logger = Logger.getLogger(ObjectManager.class);
     private static final String TOKEN_VARIABLE_NAME = "DATAONE_AUTH_TOKEN";

--- a/src/main/java/org/dataone/cn/indexer/parser/utility/SeriesIdResolver.java
+++ b/src/main/java/org/dataone/cn/indexer/parser/utility/SeriesIdResolver.java
@@ -20,14 +20,14 @@ import org.dataone.service.types.v1.Identifier;
 import org.dataone.service.types.v2.SystemMetadata;
 
 public class SeriesIdResolver {
-	
+
     public static Log log = LogFactory.getLog(SeriesIdResolver.class);
 
     /**
-     * Method to find HEAD PID for a given SID.
-     * If the provided identifier is already a PID, then it will simply be returned.
-     * If the provided identifier is a SID, then the latest SystemMetadata will be fetched
-     * and the PID for this latest revision will be returned.
+     * Method to find HEAD PID for a given SID. If the provided identifier is already a PID, then it
+     * will simply be returned. If the provided identifier is a SID, then the latest SystemMetadata
+     * will be fetched and the PID for this latest revision will be returned.
+     *
      * @param identifier the SID to look up (if a PID is provided it will simply be returned)
      * @return the HEAD PID for the given identifier
      * @throws InvalidToken
@@ -35,72 +35,87 @@ public class SeriesIdResolver {
      * @throws NotAuthorized
      * @throws NotFound
      * @throws NotImplemented
-     * @throws ClientSideException 
-     * @throws IOException 
+     * @throws ClientSideException
+     * @throws IOException
      */
-	public static Identifier getPid(Identifier identifier) throws InvalidToken, ServiceFailure, NotAuthorized, NotFound, NotImplemented, IOException, ClientSideException {
-		// check if this is this a sid
-		Identifier pid = identifier;
+    public static Identifier getPid(Identifier identifier)
+        throws InvalidToken, ServiceFailure, NotAuthorized, NotFound, NotImplemented, IOException,
+        ClientSideException {
+        // check if this is this a sid
+        Identifier pid = identifier;
         log.debug("pid===" + pid.getValue());
         String mnBaseURL = Settings.getConfiguration().getString("dataone.mn.baseURL");
         String nodeType = Settings.getConfiguration().getString("dataone.nodeType");
-        log.info("SeriesIdReolver.getPid - the current node type is "+nodeType);
+        log.info("SeriesIdResolver.getPid - the current node type is " + nodeType);
         SystemMetadata fetchedSysmeta = null;
-        if((nodeType == null || !nodeType.equalsIgnoreCase("cn")) && mnBaseURL != null && !mnBaseURL.trim().equals("")) {
-            log.info("SeriesIdReolver.getPid - get the system metadata from the mn base url"+mnBaseURL+" for the object "+identifier.getValue());
+        if ((nodeType == null || !nodeType.equalsIgnoreCase("cn")) && mnBaseURL != null
+            && !mnBaseURL.trim().equals("")) {
+            log.info(
+                "SeriesIdResolver.getPid - get the system metadata from the mn base url" + mnBaseURL
+                    + " for the object " + identifier.getValue());
             try {
-                MultipartMNode mnode = new MultipartMNode(new DefaultHttpMultipartRestClient(), mnBaseURL);
+                MultipartMNode mnode =
+                    new MultipartMNode(new DefaultHttpMultipartRestClient(), mnBaseURL);
                 fetchedSysmeta = mnode.getSystemMetadata(null, identifier);
             } catch (Exception e) {
-                log.warn("SeriesIdReolver.getPid - can't get the system metadata from the mn "+mnBaseURL+ " for the object "+pid.getValue()+
-                        " since "+e.getMessage()+". We will try to get it from cn.");
+                log.warn("SeriesIdResolver.getPid - can't get the system metadata from the mn "
+                             + mnBaseURL + " for the object " + pid.getValue() + " since "
+                             + e.getMessage() + ". We will try to get it from cn.");
             }
         }
-        if( fetchedSysmeta == null) {
-            log.info("SeriesIdReolver.getPid - get the system metadata for the object "+identifier.getValue()+" from the cn since the current node is cn or the systemmetadata is not available on a mn with baseurl "+mnBaseURL);
+        if (fetchedSysmeta == null) {
+            log.info("SeriesIdResolver.getPid - get the system metadata for the object "
+                         + identifier.getValue()
+                         + " from the cn since the current node is cn or the systemmetadata is not"
+                         + " available on a mn with baseurl " + mnBaseURL);
             fetchedSysmeta = D1Client.getCN().getSystemMetadata(null, identifier);
         }
-        if (fetchedSysmeta != null && !fetchedSysmeta.getIdentifier().getValue().equals(identifier.getValue())) {
-            log.debug("Found pid: " + fetchedSysmeta.getIdentifier().getValue() + " for sid: " + identifier.getValue());
+        if (fetchedSysmeta != null && !fetchedSysmeta.getIdentifier().getValue()
+            .equals(identifier.getValue())) {
+            log.debug("Found pid: " + fetchedSysmeta.getIdentifier().getValue() + " for sid: "
+                          + identifier.getValue());
             pid = fetchedSysmeta.getIdentifier();
         }
-        
+
         return pid;
-	}
-	
-	/**
-	 * Check if the given identifier is a PID or a SID
-	 * @param identifier
-	 * @return true if the identifier is a SID, false if a PID
-	 * @throws NotFound 
-	 * @throws ServiceFailure 
-	 * @throws NotImplemented 
-	 * @throws NotAuthorized 
-	 * @throws InvalidToken 
-	 * @throws MarshallingException 
-	 * @throws IOException 
-	 * @throws IllegalAccessException 
-	 * @throws InstantiationException 
-	 */
-	public static boolean isSeriesId(Identifier identifier) throws InvalidToken, NotAuthorized, NotImplemented, 
-	           ServiceFailure, NotFound, InstantiationException, IllegalAccessException, IOException, MarshallingException {
-		
-		// if we have system metadata available via HZ map, then it's a PID
-	    String relativeObjPath = null;//we don't know the path
-		SystemMetadata systemMetadata = ObjectManager.getInstance().getSystemMetadata(identifier.getValue(), relativeObjPath);
-		if (systemMetadata != null) {
-			return false;
-		}
-		
-		//TODO: check that it's not just bogus value by looking up the pid?
+    }
+
+    /**
+     * Check if the given identifier is a PID or a SID
+     *
+     * @param identifier
+     * @return true if the identifier is a SID, false if a PID
+     * @throws NotFound
+     * @throws ServiceFailure
+     * @throws NotImplemented
+     * @throws NotAuthorized
+     * @throws InvalidToken
+     * @throws MarshallingException
+     * @throws IOException
+     * @throws IllegalAccessException
+     * @throws InstantiationException
+     */
+    public static boolean isSeriesId(Identifier identifier)
+        throws InvalidToken, NotAuthorized, NotImplemented, ServiceFailure, NotFound,
+        InstantiationException, IllegalAccessException, IOException, MarshallingException {
+
+        // if we have system metadata available via HZ map, then it's a PID
+        String relativeObjPath = null;//we don't know the path
+        SystemMetadata systemMetadata =
+            ObjectManager.getInstance().getSystemMetadata(identifier.getValue(), relativeObjPath);
+        if (systemMetadata != null) {
+            return false;
+        }
+
+        //TODO: check that it's not just bogus value by looking up the pid?
 //		Identifier pid = getPid(identifier);
 //		if (pid.equals(identifier)) {
 //			return false;
 //		}
-		
-		// okay, it's a SID
-		return true;
-		
-	}
-	
+
+        // okay, it's a SID
+        return true;
+
+    }
+
 }

--- a/src/main/resources/org/dataone/configuration/index-processor.properties
+++ b/src/main/resources/org/dataone/configuration/index-processor.properties
@@ -1,5 +1,5 @@
-#index.d1node.baseURL=https://dev.nceas.ucsb.edu/knb/d1/mn
-index.d1node.baseURL=https://valley.duckdns.org/metacat/d1/mn
+#dataone.mn.baseURL=https://dev.nceas.ucsb.edu/knb/d1/mn
+dataone.mn.baseURL=https://valley.duckdns.org/metacat/d1/mn
 index.data.root.directory=/var/metacat/data
 index.document.root.directory=/var/metacat/documents
 

--- a/src/test/java/org/dataone/cn/indexer/IndexWorkerTest.java
+++ b/src/test/java/org/dataone/cn/indexer/IndexWorkerTest.java
@@ -153,7 +153,7 @@ public class IndexWorkerTest {
         File defaultFile = new File (propertyFilePath);
         //The one from the user specified location
         assertTrue(IndexWorker.propertyFilePath.equals(propertyFilePath));
-        assertTrue(Settings.getConfiguration().getString("index.d1node.baseURL").
+        assertTrue(Settings.getConfiguration().getString("dataone.mn.baseURL").
                 equals("https://valley.duckdns.org/metacat/d1/mn"));
         assertTrue(Settings.getConfiguration().
                 getString("index.data.root.directory").equals("/var/metacat/data"));
@@ -164,7 +164,7 @@ public class IndexWorkerTest {
         String propertyFilePath2 = "./src/test/resources/org/dataone/configuration/index-processor-2.properties";
         IndexWorker.loadAdditionalPropertyFile(propertyFilePath2);
         assertTrue(IndexWorker.propertyFilePath.equals(propertyFilePath));
-        assertTrue(Settings.getConfiguration().getString("index.d1node.baseURL").
+        assertTrue(Settings.getConfiguration().getString("dataone.mn.baseURL").
                 equals("https://valley.duckdns.org/metacat/d1/mn"));
         assertTrue(Settings.getConfiguration().
                 getString("index.data.root.directory").equals("/objects"));

--- a/src/test/resources/org/dataone/configuration/index-processor-2.properties
+++ b/src/test/resources/org/dataone/configuration/index-processor-2.properties
@@ -1,5 +1,5 @@
-#index.d1node.baseURL=https://dev.nceas.ucsb.edu/knb/d1/mn
-index.d1node.baseURL=https://valley.duckdns.org/metacat/d1/mn
+#dataone.mn.baseURL=https://dev.nceas.ucsb.edu/knb/d1/mn
+dataone.mn.baseURL=https://valley.duckdns.org/metacat/d1/mn
 index.data.root.directory=/objects
 index.document.root.directory=/objects
 

--- a/src/test/resources/org/dataone/configuration/index-processor.properties
+++ b/src/test/resources/org/dataone/configuration/index-processor.properties
@@ -1,5 +1,5 @@
-#index.d1node.baseURL=https://dev.nceas.ucsb.edu/knb/d1/mn
-index.d1node.baseURL=https://valley.duckdns.org/metacat/d1/mn
+#dataone.mn.baseURL=https://dev.nceas.ucsb.edu/knb/d1/mn
+dataone.mn.baseURL=https://valley.duckdns.org/metacat/d1/mn
 index.data.root.directory=/
 index.document.root.directory=/
 


### PR DESCRIPTION
see #67 

The next step is to clean up the index.d1node.baseURL from the metacat codebase, but note that this PR is backwards (forwards?) compatible - i.e. it should not require any changes in order for indexer to continue working when co-deployed with metacat. 