### PR TITLE
Liveness probe to avoid dead startups

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,8 @@ RUN apt update && apt -y install \
     nano
 
 #Add a user & group with id=1001 and name=d1indexer
-RUN groupadd -g 1000 d1indexer && useradd -u 1000 -g 1000 d1indexer
+RUN groupadd -g 1000 d1indexer && useradd -u 1000 -g 1000 d1indexer \
+    && touch ./livenessprobe
 
 # The most recently built jar file is copied from the maven build directory to this dir by maven, so that
 # it can be copied to the image.
@@ -28,6 +29,7 @@ COPY ./docker/entrypoint.sh .
 # Change the ownership of the jar and sh files
 RUN chown d1indexer dataone-index-worker-${TAG}-shaded.jar
 RUN chown d1indexer entrypoint.sh
+RUN chown d1indexer livenessprobe
 
 #Run Container as d1indexer
 USER 1000

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -27,7 +27,7 @@ version: 1.0.1-develop
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.0.0"
+appVersion: "3.0.1-SNAPSHOT"
 
 # Chart dependencies
 dependencies:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -56,8 +56,15 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - test $(($(date +%s) - $(stat -f %m /var/lib/dataone-indexer/livenessprobe))) -lt 20
+                - test $(($(date +%s) - $(stat -c %Y /var/lib/dataone-indexer/livenessprobe))) -lt 20
             initialDelaySeconds: 20
+            periodSeconds: 15
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - test $(($(date +%s) - $(stat -c %Y /var/lib/dataone-indexer/livenessprobe))) -lt 20
             periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -59,13 +59,6 @@ spec:
                 - test $(($(date +%s) - $(stat -c %Y /var/lib/dataone-indexer/livenessprobe))) -lt 20
             initialDelaySeconds: 20
             periodSeconds: 15
-          readinessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - test $(($(date +%s) - $(stat -c %Y /var/lib/dataone-indexer/livenessprobe))) -lt 20
-            periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -25,8 +25,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.affinity }}
-      affinity: {{- include "idxhelpers.tplvalues.render" (dict "value" .Values.affinity "context"
-      $) | nindent 8 }}
+      affinity: {{- include "idxhelpers.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector: {{- include "idxhelpers.tplvalues.render" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
@@ -52,15 +51,14 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          #     initialDelaySeconds:
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - test $(($(date +%s) - $(stat -f %m /var/lib/dataone-indexer/livenessprobe))) -lt 20
+            initialDelaySeconds: 20
+            periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
@@ -130,18 +128,6 @@ spec:
               | grep -c "<schema name=\"dataone") == 1 ]]; do
               echo waiting for Solr Schema to be accessible at http://{{ $solrHost }}:
               {{- $solrPort }}$URI; sleep 1; done;
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       volumes:
         - name: {{ .Release.Name }}-config-volume
           configMap:

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.dataone</groupId>
     <artifactId>dataone-index-worker</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>dataone-index-worker</name>
     <url>http://maven.apache.org</url>

--- a/src/main/java/org/dataone/cn/indexer/IndexWorker.java
+++ b/src/main/java/org/dataone/cn/indexer/IndexWorker.java
@@ -102,17 +102,19 @@ public class IndexWorker {
 
     /**
      * Commandline main for the IndexWorker to be started.
-     * @param args
-     * @throws TimeoutException 
-     * @throws IOException 
-     * @throws ServiceFailure 
+     * @param args (not used -- command line args)
      */
-    public static void main(String[] args) throws IOException, TimeoutException, ServiceFailure {
+    public static void main(String[] args) {
         logger.info("IndexWorker.main - Starting index worker...");
         String propertyFile = null;
         loadExternalPropertiesFile(propertyFile);
-        IndexWorker worker = new IndexWorker();
-        worker.start();
+        try {
+            IndexWorker worker = new IndexWorker();
+            worker.start();
+        } catch (Exception e) {
+            logger.fatal("IndexWorker.main() exiting due to fatal error: " + e.getMessage(), e);
+            System.exit(1);
+        }
         startLivenessProbe();
     }
     


### PR DESCRIPTION
see livenessProbe for IndexWorker -- Issue #51 

This solves 2 startup issues:
1. Error while indexer attempting to connect to shared metacat PVC, when it does not yet exist (on first ever startup)
2. Error while indexer attempting to retrieve solr schema