### PR TITLE
Bugfix 48 creator query too narrow

### DIFF
--- a/src/main/resources/application-context-json-ld.xml
+++ b/src/main/resources/application-context-json-ld.xml
@@ -22,6 +22,8 @@
 				<ref bean="schema_org_funder_identifier" />
 				<ref bean="schema_org_funder_name" />
         		<ref bean="schema_org_creator_list" />
+        		<ref bean="schema_org_creator_role_name" />
+        		<ref bean="schema_org_creator_list_role_name" />
 				<ref bean="schema_org_hasPart" />
 				<ref bean="schema_org_keywords" />
 				<ref bean="schema_org_license_url" />

--- a/src/main/resources/application-context-schema-org.xml
+++ b/src/main/resources/application-context-schema-org.xml
@@ -323,6 +323,97 @@
         </constructor-arg>
     </bean>
 
+    <!-- This query extracts the name from a creator field that uses no list when there is a single creator,
+            and also nests creator fields with @type definitions.
+    {
+        "@context": {
+            "@vocab": "https://schema.org/"
+        },
+        "@graph": {
+            "creator": {
+                "@type": "Role",
+                "creator": {
+                    "@type": "Person",
+                    ...
+                    "name": "..."
+                }
+            }
+        }
+    }
+    -->
+    <bean id="schema_org_creator_role_name" class="org.dataone.cn.indexer.annotation.SparqlField">
+        <constructor-arg name="name" value="origin" />
+        <constructor-arg name="query">
+            <value>
+                <![CDATA[
+                PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                PREFIX list: <http://jena.hpl.hp.com/ARQ/list#>
+                PREFIX SO:   <http://schema.org/>
+
+                SELECT (?name as ?origin)
+                WHERE {
+                    ?dsId rdf:type SO:Dataset .
+                    ?dsId SO:creator $creator .
+                    $creator SO:creator ?role .
+                    $role SO:name ?name .
+                }
+                ]]>
+            </value>
+        </constructor-arg>
+    </bean>
+
+    <!-- This query extracts the names from a creator field that uses ordered list syntax when there are multiple creators,
+            and also nests creator fields with @type definitions.
+    {
+        "@context": {
+            "@vocab": "https://schema.org/"
+        },
+        "@graph": {
+            "creator": [
+                {
+                    "@type": "Role",
+                    "creator": {
+                        "@type": "Person",
+                        ...
+                        "name": "Person 1"
+                    }
+                },
+                {
+                    "@type": "Role",
+                    "creator": {
+                        "@type": "Person",
+                        ...
+                        "name": "Person 2"
+                    }
+                }
+            ]
+        }
+    }
+    -->
+    <bean id="schema_org_creator_list_role_name" class="org.dataone.cn.indexer.annotation.SparqlField">
+        <constructor-arg name="name" value="origin" />
+        <constructor-arg name="query">
+            <value>
+                <![CDATA[
+                PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                PREFIX list: <http://jena.hpl.hp.com/ARQ/list#>
+                PREFIX SO:   <http://schema.org/>
+
+                SELECT (?name as ?origin)
+                WHERE {
+                    ?dsId rdf:type SO:Dataset .
+                    ?dsId SO:creator ?creatorList .
+                    ?creatorList list:member ?creator .
+                    ?creatorList list:index ?pos .
+                    ?creator SO:creator ?role .
+                    ?role SO:name ?name .
+                }
+                order by (?pos)
+                ]]>
+            </value>
+        </constructor-arg>
+    </bean>
+
     <bean id="schema_org_prov_hadDerivation" class="org.dataone.cn.indexer.annotation.SparqlField">
         <constructor-arg name="name" value="prov_hasDerivations" />
         <constructor-arg name="query">

--- a/src/test/java/org/dataone/cn/index/JsonLdSubprocessorTest.java
+++ b/src/test/java/org/dataone/cn/index/JsonLdSubprocessorTest.java
@@ -90,6 +90,11 @@ public class JsonLdSubprocessorTest extends DataONESolrJettyTestBase {
     private String schemaOrgTestDocDryad2Pid = "doi.org_10.5061_dryad.41sk145.jsonld";
     private Resource schemaOrgTesHakaiDeep;
     private String schemaOrgTesHakaiDeepPid = "hakai-deep-schema.jsonld";
+    private Resource schemaOrgTestCreatorRole;
+    private String schemaOrgTestCreatorRolePid = "creator-role.jsonld";
+    private Resource schemaOrgTestCreatorRoleList;
+    private String schemaOrgTestCreatorRoleListPid = "creator-role-list.jsonld";
+
 
     /* An instance of the RDF/XML Subprocessor */
     private JsonLdSubprocessor jsonLdSubprocessor;
@@ -122,6 +127,8 @@ public class JsonLdSubprocessorTest extends DataONESolrJettyTestBase {
         schemaOrgTestDocDryad1 = (Resource) context.getBean("schemaOrgTestDryad1");
         schemaOrgTestDocDryad2 = (Resource) context.getBean("schemaOrgTestDryad2");
         schemaOrgTesHakaiDeep = (Resource) context.getBean("schemaOrgTesHakaiDeep");
+        schemaOrgTestCreatorRole = (Resource) context.getBean("schemaOrgTestCreatorRole");
+        schemaOrgTestCreatorRoleList = (Resource) context.getBean("schemaOrgTestCreatorRoleList");
 
         // instantiate the subprocessor
         jsonLdSubprocessor = (JsonLdSubprocessor) context.getBean("jsonLdSubprocessor");
@@ -532,5 +539,57 @@ public class JsonLdSubprocessorTest extends DataONESolrJettyTestBase {
         String[] license = {"https://creativecommons.org/licenses/by/4.0/"};
         assertTrue(compareFieldValue(id, "licenseUrl", license));
     }
-    
+
+    /**
+     * Test that the JsonLdSubprocessor can successfully index JSONLD documents with creator roles.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCreatorRole() throws Exception {
+        String id = schemaOrgTestCreatorRolePid;
+        indexObjectToSolr(id, schemaOrgTestCreatorRole);
+
+        Thread.sleep(2*SLEEPTIME);
+        // now process the tasks
+        //processor.processIndexTaskQueue();
+        for (int i=0; i<TIMES; i++) {
+            try {
+                Thread.sleep(SLEEP);
+                assertPresentInSolrIndex(id);
+                break;
+            } catch (Throwable e) {
+                
+            }
+        }
+        assertTrue(compareFieldValue(id, "authorGivenName", "Ian"));
+        assertTrue(compareFieldValue(id, "authorLastName", "Nesbitt"));
+    }
+
+    /**
+     * Test that the JsonLdSubprocessor can successfully index JSONLD documents with creator role lists.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCreatorRoleList() throws Exception {
+        String id = schemaOrgTestCreatorRoleListPid;
+        indexObjectToSolr(id, schemaOrgTestCreatorRoleList);
+
+        Thread.sleep(2*SLEEPTIME);
+        // now process the tasks
+        //processor.processIndexTaskQueue();
+        for (int i=0; i<TIMES; i++) {
+            try {
+                Thread.sleep(SLEEP);
+                assertPresentInSolrIndex(id);
+                break;
+            } catch (Throwable e) {
+                
+            }
+        }
+        assertTrue(compareFieldValue(id, "authorGivenName", "Ian"));
+        assertTrue(compareFieldValue(id, "authorLastName", "Nesbitt"));
+    }
+
 }

--- a/src/test/java/org/dataone/cn/index/JsonLdSubprocessorTest.java
+++ b/src/test/java/org/dataone/cn/index/JsonLdSubprocessorTest.java
@@ -550,9 +550,11 @@ public class JsonLdSubprocessorTest extends DataONESolrJettyTestBase {
         String id = schemaOrgTestCreatorRolePid;
         indexObjectToSolr(id, schemaOrgTestCreatorRole);
 
-        Thread.sleep(2*SLEEPTIME);
+        //Thread.sleep(2*SLEEPTIME);
         // now process the tasks
         //processor.processIndexTaskQueue();
+        int TIMES = 2*8 + 10*2;
+        int SLEEP = 500;
         for (int i=0; i<TIMES; i++) {
             try {
                 Thread.sleep(SLEEP);

--- a/src/test/java/org/dataone/cn/index/JsonLdSubprocessorTest.java
+++ b/src/test/java/org/dataone/cn/index/JsonLdSubprocessorTest.java
@@ -578,9 +578,11 @@ public class JsonLdSubprocessorTest extends DataONESolrJettyTestBase {
         String id = schemaOrgTestCreatorRoleListPid;
         indexObjectToSolr(id, schemaOrgTestCreatorRoleList);
 
-        Thread.sleep(2*SLEEPTIME);
+        //Thread.sleep(2*SLEEPTIME);
         // now process the tasks
         //processor.processIndexTaskQueue();
+        int TIMES = 2*8 + 10*2;
+        int SLEEP = 500;
         for (int i=0; i<TIMES; i++) {
             try {
                 Thread.sleep(SLEEP);

--- a/src/test/resources/org/dataone/cn/index/resources/d1_testdocs/json-ld/creator-role-list/creator-role-list.jsonld
+++ b/src/test/resources/org/dataone/cn/index/resources/d1_testdocs/json-ld/creator-role-list/creator-role-list.jsonld
@@ -1,0 +1,44 @@
+{
+    "@context": "http://schema.org/",
+    "@type":"Dataset",
+    "description":"Vocab https://schema.org/, creator without @list and with @type: 'Role'. Modeled after CanWIN SO format.",
+    "name":"test of alternative creator field configuration",
+    "creator": [
+        {
+            "@type": "Role",
+            "creator": {
+                "@type": "Person",
+                "Affiliation": {
+                    "@type": "Organization",
+                    "name": "National Center for Ecological Analaysis and Synthesis"
+                },
+                "Email": "nesbitt@nceas.ucsb.edu",
+                "Identifier": {
+                    "@type": "PropertyValue",
+                    "propertyID": "https://registry.identifiers.org/registry/orcid",
+                    "url": "http://orcid.org/0000-0001-5828-6070",
+                    "value": "0000-0001-5828-6070"
+                },
+                "Name": "Nesbitt, Ian\t"
+            }
+        },
+        {
+            "@type": "Role",
+            "creator": {
+                "@type": "Person",
+                "Affiliation": {
+                    "@type": "Organization",
+                    "name": "National Center for Ecological Analaysis and Synthesis"
+                },
+                "Email": "tao@nceas.ucsb.edu",
+                "Identifier": {
+                    "@type": "PropertyValue",
+                    "propertyID": "https://registry.identifiers.org/registry/orcid",
+                    "url": "http://orcid.org/0000-0002-1209-5268",
+                    "value": "0000-0002-1209-5268"
+                },
+                "Name": "Tao, Jing\t"
+            }
+        }
+    ]
+}

--- a/src/test/resources/org/dataone/cn/index/resources/d1_testdocs/json-ld/creator-role-list/systemmetadata.xml
+++ b/src/test/resources/org/dataone/cn/index/resources/d1_testdocs/json-ld/creator-role-list/systemmetadata.xml
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ns1:systemMetadata xmlns:ns1="http://ns.dataone.org/service/types/v2.0">
+    <serialVersion>1</serialVersion>
+  <identifier>creator-role-list.jsonld</identifier>
+  <formatId>science-on-schema.org/Dataset;ld+json</formatId>
+  <size>498</size>
+  <checksum algorithm="MD5"></checksum>
+  <submitter>dataone_integration_test_user</submitter>
+  <rightsHolder>dataone_integration_test_user</rightsHolder>
+  <accessPolicy>
+    <allow>
+      <subject>dataone_public_user</subject>
+      <permission>read</permission>
+    </allow>
+    <allow>
+      <subject>dataone_integration_test_user</subject>
+      <permission>write</permission>
+    </allow>
+  </accessPolicy>
+  <replicationPolicy replicationAllowed="true"/>
+  <dateUploaded>2024-08-17T11:59:47.171874</dateUploaded>
+  <dateSysMetadataModified>2024-08-17T11:59:47.173344</dateSysMetadataModified>
+  <originMemberNode>test_documents</originMemberNode>
+  <authoritativeMemberNode>test_documents</authoritativeMemberNode>
+</ns1:systemMetadata>
+

--- a/src/test/resources/org/dataone/cn/index/resources/d1_testdocs/json-ld/creator-role-list/systemmetadata.xml
+++ b/src/test/resources/org/dataone/cn/index/resources/d1_testdocs/json-ld/creator-role-list/systemmetadata.xml
@@ -18,8 +18,8 @@
     </allow>
   </accessPolicy>
   <replicationPolicy replicationAllowed="true"/>
-  <dateUploaded>2024-08-17T11:59:47.171874</dateUploaded>
-  <dateSysMetadataModified>2024-08-17T11:59:47.173344</dateSysMetadataModified>
+  <dateUploaded>2024-08-17T12:59:47.171874</dateUploaded>
+  <dateSysMetadataModified>2024-08-17T12:59:47.173344</dateSysMetadataModified>
   <originMemberNode>test_documents</originMemberNode>
   <authoritativeMemberNode>test_documents</authoritativeMemberNode>
 </ns1:systemMetadata>

--- a/src/test/resources/org/dataone/cn/index/resources/d1_testdocs/json-ld/creator-role/creator-role.jsonld
+++ b/src/test/resources/org/dataone/cn/index/resources/d1_testdocs/json-ld/creator-role/creator-role.jsonld
@@ -1,0 +1,24 @@
+{
+    "@context": "http://schema.org/",
+    "@type":"Dataset",
+    "description":"Vocab https://schema.org/, creator without @list and with @type: 'Role'. Modeled after CanWIN SO format.",
+    "name":"test of alternative creator field configuration",
+    "creator": {
+        "@type": "Role",
+        "creator": {
+            "@type": "Person",
+            "Affiliation": {
+                "@type": "Organization",
+                "name": "National Center for Ecological Analaysis and Synthesis"
+            },
+            "Email": "nesbitt@nceas.ucsb.edu",
+            "Identifier": {
+                "@type": "PropertyValue",
+                "propertyID": "https://registry.identifiers.org/registry/orcid",
+                "url": "http://orcid.org/0000-0001-5828-6070",
+                "value": "0000-0001-5828-6070"
+            },
+            "Name": "Nesbitt, Ian\t"
+        }
+    }
+}

--- a/src/test/resources/org/dataone/cn/index/resources/d1_testdocs/json-ld/creator-role/systemmetadata.xml
+++ b/src/test/resources/org/dataone/cn/index/resources/d1_testdocs/json-ld/creator-role/systemmetadata.xml
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ns1:systemMetadata xmlns:ns1="http://ns.dataone.org/service/types/v2.0">
+    <serialVersion>1</serialVersion>
+  <identifier>creator-role.jsonld</identifier>
+  <formatId>science-on-schema.org/Dataset;ld+json</formatId>
+  <size>498</size>
+  <checksum algorithm="MD5"></checksum>
+  <submitter>dataone_integration_test_user</submitter>
+  <rightsHolder>dataone_integration_test_user</rightsHolder>
+  <accessPolicy>
+    <allow>
+      <subject>dataone_public_user</subject>
+      <permission>read</permission>
+    </allow>
+    <allow>
+      <subject>dataone_integration_test_user</subject>
+      <permission>write</permission>
+    </allow>
+  </accessPolicy>
+  <replicationPolicy replicationAllowed="true"/>
+  <dateUploaded>2024-08-17T11:59:47.171874</dateUploaded>
+  <dateSysMetadataModified>2024-08-17T11:59:47.173344</dateSysMetadataModified>
+  <originMemberNode>test_documents</originMemberNode>
+  <authoritativeMemberNode>test_documents</authoritativeMemberNode>
+</ns1:systemMetadata>
+

--- a/src/test/resources/org/dataone/cn/index/test-context.xml
+++ b/src/test/resources/org/dataone/cn/index/test-context.xml
@@ -506,6 +506,16 @@ xmlns:context="http://www.springframework.org/schema/context"
                          value="org/dataone/cn/index/resources/d1_testdocs/json-ld/doi.org_10.5061_dryad.41sk145/doi.org_10.5061_dryad.41sk145.jsonld"/>
     </bean>
     
+    <bean id="schemaOrgTestCreatorRole" class="org.springframework.core.io.ClassPathResource" >
+        <constructor-arg type="java.lang.String"
+                         value="org/dataone/cn/index/resources/d1_testdocs/json-ld/creator-role/creator-role.jsonld"/>
+    </bean>
+    
+    <bean id="schemaOrgTestCreatorRoleList" class="org.springframework.core.io.ClassPathResource" >
+        <constructor-arg type="java.lang.String"
+                         value="org/dataone/cn/index/resources/d1_testdocs/json-ld/creator-role-list/creator-role-list.jsonld"/>
+    </bean>
+    
     <bean id="emlWithDataTableTestDoc" class="org.springframework.core.io.ClassPathResource" >
         <constructor-arg type="java.lang.String"
                          value="org/dataone/cn/index/resources/d1_testdocs/eml220/eml2.2.0testdatatable/eml2.2.0testdatatable.xml"/>


### PR DESCRIPTION
Sorry for the weekend ping. This PR attempts to broaden support for the types of creator role that can be defined in Schema.org JSON-LD metadata. I'm having trouble getting all of the pieces running on my machine, so these changes have not been tested.

Notes:

1. I added two sparql queries, one for the creator role definition without a list (sometimes used when there is only one creator) and one for the creator role definition WITH an ordered list. I commented with examples of each, and added tests and systemmetadata for each.

2. I did not add a query for author email as Matt [Matt demoed here](https://github.com/DataONEorg/dataone-indexer/issues/48#issuecomment-1758264499), as I did not see a field for author email defined in the Solr schema. If someone can suggest what Solr field to use for email and/or ORCiD, I will add those to the query.

I'm adding @artntek to the list of reviewers since I imagine he has a working setup and can test the changes.