### PR TITLE
Adding GeoCoordinates queries to address #100

### DIFF
--- a/src/main/resources/application-context-json-ld.xml
+++ b/src/main/resources/application-context-json-ld.xml
@@ -30,6 +30,10 @@
 				<ref bean="schema_org_geoShape_box_west" />
 				<ref bean="schema_org_geoShape_box_north" />
 				<ref bean="schema_org_geoShape_box_east" />
+				<ref bean="schema_org_geoCoordinates_south" />
+				<ref bean="schema_org_geoCoordinates_west" />
+				<ref bean="schema_org_geoCoordinates_north" />
+				<ref bean="schema_org_geoCoordinates_east" />
 				<ref bean="schema_org_geohash_1" />
 				<ref bean="schema_org_geohash_2" />
 				<ref bean="schema_org_geohash_3" />

--- a/src/main/resources/application-context-schema-org.xml
+++ b/src/main/resources/application-context-schema-org.xml
@@ -576,6 +576,110 @@
         <property name="converter" ref="solrLongitudeConverter" />
     </bean>
 
+<!-- Extract south bounding coordinate from a 'SO:spatialCoverage' property of type 'GeoCoordinates'. -->
+<bean id="schema_org_geoCoordinates_south" class="org.dataone.cn.indexer.annotation.SparqlField">
+    <constructor-arg name="name" value="southBoundCoord" />
+    <constructor-arg name="query">
+        <value>
+            <![CDATA[
+                PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                PREFIX SO:   <http://schema.org/>
+
+                SELECT ?southBoundCoord
+                WHERE {
+                    ?datasetId rdf:type           SO:Dataset .
+                    ?datasetId SO:spatialCoverage ?spatial .
+                    ?spatial   rdf:type           SO:Place .
+                    ?spatial   SO:geo             ?geo .
+                    ?geo       rdf:type           SO:GeoCoordinates .
+                    ?geo       SO:latitude        ?southBoundCoord .
+                }
+                LIMIT 1
+            ]]>
+        </value>
+    </constructor-arg>
+    <property name="converter" ref="solrLatitudeConverter" />
+</bean>
+
+<!-- Extract west bounding coordinate from a 'SO:spatialCoverage' property of type 'GeoCoordinates'. -->
+<bean id="schema_org_geoCoordinates_west" class="org.dataone.cn.indexer.annotation.SparqlField">
+    <constructor-arg name="name" value="westBoundCoord" />
+    <constructor-arg name="query">
+        <value>
+            <![CDATA[
+                PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                PREFIX SO:   <http://schema.org/>
+
+                SELECT ?westBoundCoord
+                WHERE {
+                    ?datasetId rdf:type           SO:Dataset .
+                    ?datasetId SO:spatialCoverage ?spatial .
+                    ?spatial   rdf:type           SO:Place .
+                    ?spatial   SO:geo             ?geo .
+                    ?geo       rdf:type           SO:GeoCoordinates .
+                    ?geo       SO:longitude       ?westBoundCoord .
+                }
+                LIMIT 1
+            ]]>
+        </value>
+    </constructor-arg>
+    <property name="converter" ref="solrLongitudeConverter" />
+</bean>
+
+<!-- Extract north bounding coordinate from a 'SO:spatialCoverage' property of type 'GeoCoordinates'. -->
+<bean id="schema_org_geoCoordinates_north" class="org.dataone.cn.indexer.annotation.SparqlField">
+    <constructor-arg name="name" value="northBoundCoord" />
+    <constructor-arg name="query">
+        <value>
+            <![CDATA[
+                PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                PREFIX SO:   <http://schema.org/>
+
+                SELECT ?northBoundCoord
+                WHERE {
+                    ?datasetId rdf:type           SO:Dataset .
+                    ?datasetId SO:spatialCoverage ?spatial .
+                    ?spatial   rdf:type           SO:Place .
+                    ?spatial   SO:geo             ?geo .
+                    ?geo       rdf:type           SO:GeoCoordinates .
+                    ?geo       SO:latitude        ?northBoundCoord .
+                }
+                LIMIT 1
+            ]]>
+        </value>
+    </constructor-arg>
+    <property name="converter" ref="solrLatitudeConverter" />
+</bean>
+
+<!-- Extract east bounding coordinate from a 'SO:spatialCoverage' property of type 'GeoCoordinates'. -->
+<bean id="schema_org_geoCoordinates_east" class="org.dataone.cn.indexer.annotation.SparqlField">
+    <constructor-arg name="name" value="eastBoundCoord" />
+    <constructor-arg name="query">
+        <value>
+            <![CDATA[
+                PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                PREFIX SO:   <http://schema.org/>
+
+                SELECT ?eastBoundCoord
+                WHERE {
+                    ?datasetId rdf:type           SO:Dataset .
+                    ?datasetId SO:spatialCoverage ?spatial .
+                    ?spatial   rdf:type           SO:Place .
+                    ?spatial   SO:geo             ?geo .
+                    ?geo       rdf:type           SO:GeoCoordinates .
+                    ?geo       SO:longitude       ?eastBoundCoord .
+                }
+                LIMIT 1
+            ]]>
+        </value>
+    </constructor-arg>
+    <property name="converter" ref="solrLongitudeConverter" />
+</bean>
+
     <!-- Extract 'SO:spatialCoverage'. This property can have several different forms, for different
          types of spatial coverage representations. if the value is simple text (i.e. not SO:Place),
          then it should be assigned to Solr 'namedLocation' field,

--- a/src/test/java/org/dataone/cn/index/JsonLdSubprocessorTest.java
+++ b/src/test/java/org/dataone/cn/index/JsonLdSubprocessorTest.java
@@ -90,8 +90,8 @@ public class JsonLdSubprocessorTest extends DataONESolrJettyTestBase {
     private String schemaOrgTestDocDryad2Pid = "doi.org_10.5061_dryad.41sk145.jsonld";
     private Resource schemaOrgTesHakaiDeep;
     private String schemaOrgTesHakaiDeepPid = "hakai-deep-schema.jsonld";
-    private Resource schemaOrgTestGeo;
-    private String schemaOrgTestGeoCoordinates = "geocoordinates.jsonld";
+    private Resource schemaOrgTestGeoCoordinates;
+    private String schemaOrgTestGeoCoordinatesPid = "geocoordinates.jsonld";
 
     /* An instance of the RDF/XML Subprocessor */
     private JsonLdSubprocessor jsonLdSubprocessor;
@@ -124,6 +124,7 @@ public class JsonLdSubprocessorTest extends DataONESolrJettyTestBase {
         schemaOrgTestDocDryad1 = (Resource) context.getBean("schemaOrgTestDryad1");
         schemaOrgTestDocDryad2 = (Resource) context.getBean("schemaOrgTestDryad2");
         schemaOrgTesHakaiDeep = (Resource) context.getBean("schemaOrgTesHakaiDeep");
+        schemaOrgTestGeoCoordinates = (Resource) context.getBean("schemaOrgTestGeoCoordinates");
 
         // instantiate the subprocessor
         jsonLdSubprocessor = (JsonLdSubprocessor) context.getBean("jsonLdSubprocessor");
@@ -542,8 +543,8 @@ public class JsonLdSubprocessorTest extends DataONESolrJettyTestBase {
      */
     @Test
     public void testGeoCoordinates() throws Exception {
-        String id = schemaOrgTestGeoCoordinates;
-        indexObjectToSolr(id, schemaOrgTestGeo);
+        String id = schemaOrgTestGeoCoordinatesPid;
+        indexObjectToSolr(id, schemaOrgTestGeoCoordinates);
 
         Thread.sleep(2*SLEEPTIME);
         // now process the tasks

--- a/src/test/java/org/dataone/cn/index/JsonLdSubprocessorTest.java
+++ b/src/test/java/org/dataone/cn/index/JsonLdSubprocessorTest.java
@@ -90,6 +90,8 @@ public class JsonLdSubprocessorTest extends DataONESolrJettyTestBase {
     private String schemaOrgTestDocDryad2Pid = "doi.org_10.5061_dryad.41sk145.jsonld";
     private Resource schemaOrgTesHakaiDeep;
     private String schemaOrgTesHakaiDeepPid = "hakai-deep-schema.jsonld";
+    private Resource schemaOrgTestGeo;
+    private String schemaOrgTestGeoCoordinates = "geocoordinates.jsonld";
 
     /* An instance of the RDF/XML Subprocessor */
     private JsonLdSubprocessor jsonLdSubprocessor;
@@ -531,6 +533,38 @@ public class JsonLdSubprocessorTest extends DataONESolrJettyTestBase {
         assertTrue(compareFieldValue(id, "serviceEndpoint", urls));
         String[] license = {"https://creativecommons.org/licenses/by/4.0/"};
         assertTrue(compareFieldValue(id, "licenseUrl", license));
+    }
+    
+    /**
+     * Test that the JsonLdSubprocessor can sucessfully index JSONLD Dataset description documents from Dryad.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testGeoCoordinates() throws Exception {
+        String id = schemaOrgTestGeoCoordinates;
+        indexObjectToSolr(id, schemaOrgTestGeo);
+
+        Thread.sleep(2*SLEEPTIME);
+        // now process the tasks
+        //processor.processIndexTaskQueue();
+        for (int i=0; i<TIMES; i++) {
+            try {
+                Thread.sleep(SLEEP);
+                assertPresentInSolrIndex(id);
+                break;
+            } catch (Throwable e) {
+                
+            }
+        }
+        String [] coord = {"36.7016"};
+        assertTrue(compareFieldValue(id, "southBoundCoord", coord));
+        coord[0] = "-121.90504";
+        assertTrue(compareFieldValue(id, "westBoundCoord", coord));
+        coord[0] = "36.7016";
+        assertTrue(compareFieldValue(id, "northBoundCoord", coord));
+        coord[0] = "-121.90504";
+        assertTrue(compareFieldValue(id, "eastBoundCoord", coord));
     }
     
 }

--- a/src/test/java/org/dataone/cn/index/JsonLdSubprocessorTest.java
+++ b/src/test/java/org/dataone/cn/index/JsonLdSubprocessorTest.java
@@ -546,9 +546,11 @@ public class JsonLdSubprocessorTest extends DataONESolrJettyTestBase {
         String id = schemaOrgTestGeoCoordinatesPid;
         indexObjectToSolr(id, schemaOrgTestGeoCoordinates);
 
-        Thread.sleep(2*SLEEPTIME);
+        //Thread.sleep(2*SLEEPTIME);
         // now process the tasks
         //processor.processIndexTaskQueue();
+        int TIMES = 2*8 + 10*2;
+        int SLEEP = 500;
         for (int i=0; i<TIMES; i++) {
             try {
                 Thread.sleep(SLEEP);

--- a/src/test/resources/org/dataone/cn/index/resources/d1_testdocs/json-ld/geocoordinates/geocoordinates.jsonld
+++ b/src/test/resources/org/dataone/cn/index/resources/d1_testdocs/json-ld/geocoordinates/geocoordinates.jsonld
@@ -101,21 +101,6 @@
           "@type": "GeoCoordinates",
           "latitude": "36.7016",
           "longitude": "-121.90504"
-        },
-        {
-          "@type": "GeoCoordinates",
-          "latitude": "36.837017",
-          "longitude": "-121.88215"
-        },
-        {
-          "@type": "GeoCoordinates",
-          "latitude": "36.873",
-          "longitude": "-122.03484"
-        },
-        {
-          "@type": "GeoCoordinates",
-          "latitude": "37.04653",
-          "longitude": "-122.404"
         }
       ]
     },

--- a/src/test/resources/org/dataone/cn/index/resources/d1_testdocs/json-ld/geocoordinates/geocoordinates.jsonld
+++ b/src/test/resources/org/dataone/cn/index/resources/d1_testdocs/json-ld/geocoordinates/geocoordinates.jsonld
@@ -1,0 +1,123 @@
+{
+    "@context": {
+      "@vocab": "https://schema.org/",
+      "datacite": "http://purl.org/spar/datacite/"
+    },
+    "@id": "https://doi.org/10.26022/IEDA/111561",
+    "@type": "Dataset",
+    "author": {
+      "@list": [
+        {
+          "@type": "Role",
+          "author": [
+            {
+              "@type": "Person",
+              "familyName": "Carlin",
+              "givenName": "Joseph",
+              "name": "Joseph A Carlin"
+            }
+          ],
+          "roleName": "Lead Author"
+        },
+        {}
+      ]
+    },
+    "citation": [
+      "https://doi.org/10.3389/feart.2019.00113 "
+    ],
+    "dateCreated": "2020-06-01",
+    "description": "This dataset contains sedimentological and geochronological data from 5 sediment cores collected from Monterey Bay, CA, USA. The purpose of this data was to investigate changes in sedimentation on the Monterey Bay shelf over decadal and centennial time scales. All cores were collected from continental shelf areas, in water depths of ~100 m or less, and the cores were collected in 2014 and 2017. Four of the cores were collected using a multi-corer and were less than ~35 cm in length, the fifth core was collected using a gravity corer and was ~90 cm in length. The data include grain size data, 210Pb activities, 137Cs activities, and 14C dates.  ",
+    "distribution": {
+      "@type": "DataDownload",
+      "contentUrl": "https://ecl.earthchem.org/view.php?id=1561",
+      "datePublished": "2020-06-01 00:00:00",
+      "encodingFormat": "application/vnd.ms-excel"
+    },
+    "funding": [
+      {
+        "@id": "http://www.nsf.gov/awardsearch/showAward.do?AwardNumber=9530299",
+        "@type": "MonetaryGrant",
+        "funder": {
+          "@type": "Organization",
+          "name": "National Science Foundation"
+        },
+        "identifier": "9530299",
+        "url": "http://www.nsf.gov/awardsearch/showAward.do?AwardNumber=9530299"
+      },
+      {
+        "@type": "MonetaryGrant",
+        "funder": {
+          "@type": "Organization",
+          "name": "American Chemical Society Petroleum Research Fund"
+        },
+        "identifier": "57363-UNI8"
+      }
+    ],
+    "identifier": {
+      "@type": "PropertyValue",
+      "propertyID": "https://registry.identifiers.org/registry/doi",
+      "url": "https://doi.org/10.26022/IEDA/111561",
+      "value": "doi:10.26022/IEDA/111561"
+    },
+    "inLanguage": "English",
+    "isAccessibleForFree": true,
+    "isBasedOn": [],
+    "keywords": [
+      "Monterey Bay",
+      "California Coast",
+      "Pacific Ocean",
+      "Regional (Continents, Oceans)",
+      "sediment",
+      "continental shelf",
+      "grain size",
+      "210Pb",
+      "137Cs",
+      "14C"
+    ],
+    "license": "https://spdx.org/licenses/CC-BY-SA-4.0",
+    "name": "Variability in Shelf Sedimentation in Response to Fluvial Sediment Supply and Coastal Erosion over the Past 1,000 Years in Monterey Bay, CA, USA. ",
+    "provider": {
+      "@type": "Organization",
+      "name": "EarthChem Library"
+    },
+    "publisher": {
+      "@id": "https://www.earthchem.org",
+      "@type": "Organization",
+      "contactPoint": {
+        "@type": "ContactPoint",
+        "contactType": "Customer Service",
+        "email": "info@earthchem.org",
+        "name": "Information Desk",
+        "url": "https://www.earthchem.org/contact/"
+      },
+      "name": "EarthChem Library",
+      "url": "https://www.earthchem.org/library"
+    },
+    "sameAs": "https://ecl.earthchem.org/view.php?id=1561",
+    "spatialCoverage": {
+      "@type": "Place",
+      "geo": [
+        {
+          "@type": "GeoCoordinates",
+          "latitude": "36.7016",
+          "longitude": "-121.90504"
+        },
+        {
+          "@type": "GeoCoordinates",
+          "latitude": "36.837017",
+          "longitude": "-121.88215"
+        },
+        {
+          "@type": "GeoCoordinates",
+          "latitude": "36.873",
+          "longitude": "-122.03484"
+        },
+        {
+          "@type": "GeoCoordinates",
+          "latitude": "37.04653",
+          "longitude": "-122.404"
+        }
+      ]
+    },
+    "url": "https://doi.org/10.26022/IEDA/111561"
+}

--- a/src/test/resources/org/dataone/cn/index/resources/d1_testdocs/json-ld/geocoordinates/systemmetadata.xml
+++ b/src/test/resources/org/dataone/cn/index/resources/d1_testdocs/json-ld/geocoordinates/systemmetadata.xml
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ns1:systemMetadata xmlns:ns1="http://ns.dataone.org/service/types/v2.0">
+    <serialVersion>1</serialVersion>
+  <identifier>geocoordinates.jsonld</identifier>
+  <formatId>science-on-schema.org/Dataset;ld+json</formatId>
+  <size>4207</size>
+  <checksum algorithm="MD5"></checksum>
+  <submitter>dataone_integration_test_user</submitter>
+  <rightsHolder>dataone_integration_test_user</rightsHolder>
+  <accessPolicy>
+    <allow>
+      <subject>dataone_public_user</subject>
+      <permission>read</permission>
+    </allow>
+    <allow>
+      <subject>dataone_integration_test_user</subject>
+      <permission>write</permission>
+    </allow>
+  </accessPolicy>
+  <replicationPolicy replicationAllowed="true"/>
+  <dateUploaded>2024-08-17T14:59:47.171874</dateUploaded>
+  <dateSysMetadataModified>2024-08-17T14:59:47.173344</dateSysMetadataModified>
+  <originMemberNode>test_documents</originMemberNode>
+  <authoritativeMemberNode>test_documents</authoritativeMemberNode>
+</ns1:systemMetadata>
+

--- a/src/test/resources/org/dataone/cn/index/test-context.xml
+++ b/src/test/resources/org/dataone/cn/index/test-context.xml
@@ -506,6 +506,11 @@ xmlns:context="http://www.springframework.org/schema/context"
                          value="org/dataone/cn/index/resources/d1_testdocs/json-ld/doi.org_10.5061_dryad.41sk145/doi.org_10.5061_dryad.41sk145.jsonld"/>
     </bean>
     
+    <bean id="schemaOrgTestGeoCoordinates" class="org.springframework.core.io.ClassPathResource" >
+        <constructor-arg type="java.lang.String"
+                         value="org/dataone/cn/index/resources/d1_testdocs/json-ld/geocoordinates/geocoordinates.jsonld"/>
+    </bean>
+    
     <bean id="emlWithDataTableTestDoc" class="org.springframework.core.io.ClassPathResource" >
         <constructor-arg type="java.lang.String"
                          value="org/dataone/cn/index/resources/d1_testdocs/eml220/eml2.2.0testdatatable/eml2.2.0testdatatable.xml"/>


### PR DESCRIPTION
This PR adds queries that should match the following spatialCoverage definition in a schema.org JSON-LD. It also adds a test file and accompanying systemmetadata.

```json
    "spatialCoverage": {
      "@type": "Place",
      "geo": [
        {
          "@type": "GeoCoordinates",
          "latitude": "36.7016",
          "longitude": "-121.90504"
        },
        {
          "@type": "GeoCoordinates",
          "latitude": "36.837017",
          "longitude": "-121.88215"
        },
        {
          "@type": "GeoCoordinates",
          "latitude": "36.873",
          "longitude": "-122.03484"
        },
        {
          "@type": "GeoCoordinates",
          "latitude": "37.04653",
          "longitude": "-122.404"
        }
      ]
    },
```

I once again need help testing this as I don't know how to get it set up myself.