### PR TITLE
update base image to eclipse-temurin:17.0.12_7-jre-jammy

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 #     `nerdctl build -t dataone-index-worker:2.4.0 -f docker/Dockerfile --build-arg TAG=2.4.0 .`
 # Use an OpenJDK runtime as a parent image
 # Note: the prior alpine-based openjdk image had network DNS issues, so replacing with Eclipse Temurin
-FROM eclipse-temurin:17.0.8.1_1-jre-jammy
+FROM eclipse-temurin:17.0.12_7-jre-jammy
 
 ARG TAG=3.0.0-SNAPSHOT
 ENV TAG=${TAG}


### PR DESCRIPTION
update base image to eclipse-temurin:17.0.12_7-jre-jammy, since current base has critical security vulnerabilities