### PR TITLE
feat: add support for hostPath volume in indexer

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -133,10 +133,16 @@ spec:
           configMap:
             name: {{ .Release.Name }}-indexer-configfiles
             defaultMode: 0644
-        - name:  indexer-metacat-pv
+        - name: indexer-metacat-pv
+          {{- if and .Values.persistence.hostPath .Values.persistence.hostPath.path }}
+          hostPath:
+            path: {{ tpl .Values.persistence.hostPath.path . }}
+            type: {{ .Values.persistence.hostPath.type }}
+          {{- else }}
           persistentVolumeClaim:
             claimName: {{ include "idxworker.shared.claimName" . }}
             readOnly: true
+          {{- end }}
         - name: {{ .Release.Name }}-temp-tripledb-volume
           ephemeral:
             volumeClaimTemplate:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -124,6 +124,15 @@ persistence:
   ##
   subPath: ""
 
+  ## @param persistence.hostPath Use a hostPath volume for the index worker.
+  ## This will override the claimName and use the mountPath settings.
+  hostPath:
+    ## @param persistence.hostPath.path The path on the host to use for the hostPath volume
+    path: ""
+    ## @param persistence.hostPath.type The type of hostPath volume to use
+    type: Directory
+
+
 ## @section IndexWorker properties
 ##
 idxworker:


### PR DESCRIPTION
This pull request introduces a new `hostPath` configuration in the `values.yaml` file to allow the use of a hostPath volume for the index worker. If `hostPath` is specified, the `deployment.yaml` is updated to conditionally use `hostPath`; otherwise, it will fallback to using `PersistentVolumeClaim`.

**Changes**:
- **values.yaml**: Added `hostPath` configuration.
- **deployment.yaml**: Updated to conditionally use `hostPath` if specified, otherwise fallback to `PersistentVolumeClaim`.

**Context**:
Closes #162 
