### PR TITLE
Revert "feat: add support for hostPath volume in indexer"

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -133,16 +133,10 @@ spec:
           configMap:
             name: {{ .Release.Name }}-indexer-configfiles
             defaultMode: 0644
-        - name: indexer-metacat-pv
-          {{- if and .Values.persistence.hostPath .Values.persistence.hostPath.path }}
-          hostPath:
-            path: {{ tpl .Values.persistence.hostPath.path . }}
-            type: {{ .Values.persistence.hostPath.type }}
-          {{- else }}
+        - name:  indexer-metacat-pv
           persistentVolumeClaim:
             claimName: {{ include "idxworker.shared.claimName" . }}
             readOnly: true
-          {{- end }}
         - name: {{ .Release.Name }}-temp-tripledb-volume
           ephemeral:
             volumeClaimTemplate:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -124,15 +124,6 @@ persistence:
   ##
   subPath: ""
 
-  ## @param persistence.hostPath Use a hostPath volume for the index worker.
-  ## This will override the claimName and use the mountPath settings.
-  hostPath:
-    ## @param persistence.hostPath.path The path on the host to use for the hostPath volume
-    path: ""
-    ## @param persistence.hostPath.type The type of hostPath volume to use
-    type: Directory
-
-
 ## @section IndexWorker properties
 ##
 idxworker:


### PR DESCRIPTION
Reverts DataONEorg/dataone-indexer#164 - was merged to `main` instead of `develop`