### PR TITLE
fix(helm): update RabbitMQ and Solr chart versions

### DIFF
--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
-  version: 11.16.2
+  version: 15.5.3
 - name: solr
   repository: https://charts.bitnami.com/bitnami
-  version: 9.5.5
-digest: sha256:167319ae8bd8a2acfc45180c5ed08ce0f546409d5df8da7f7892694a1b4d157c
-generated: "2025-03-26T10:19:54.965648-07:00"
+  version: 9.6.1
+digest: sha256:74898836e3668ad0e2cb0d6b2e6b17cad48177edd82e23f771c650ab30320ab4
+generated: "2025-04-22T13:27:25.070365-07:00"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.2.0"
+version: "1.2.1"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -34,7 +34,7 @@ dependencies:
   - name: rabbitmq
     condition: rabbitmq.enabled, global.rabbitmq.enabled
     repository: https://charts.bitnami.com/bitnami
-    version: 11.16.2    # rabbitmq version 3.11.18
+    version: 15.5.3    # rabbitmq version 4.0.9
     ## get full list using:  $  helm search repo bitnami/rabbitmq --versions
     ##
     ## NOTE: For upgrades beyond 10.3.9, see "Required feature flags in RabbitMQ 3.11.0":
@@ -55,5 +55,5 @@ dependencies:
   - name: solr
     condition: solr.enabled, global.solr.enabled
     repository: https://charts.bitnami.com/bitnami
-    version: 9.5.5      # solr version 9.8.1 is deployed by chart version 9.5.5
+    version: 9.6.1      # solr version 9.8.1 is deployed by chart version 9.6.1
     # get full list using:  $  helm search repo bitnami/solr --versions

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -265,6 +265,15 @@ rabbitmq:
             echo; echo "Done." >> $HOOK_LOG
             echo "* * * * * *  END lifecycle postStart hook  * * * * * *" >> $HOOK_LOG
 
+  ## @param rabbitmq.image.repository The RabbitMQ image repository
+  image:
+    ## @param rabbitmq.image.repository The RabbitMQ image repository
+    repository: bitnami/rabbitmq
+    ## @param rabbitmq.image.tag The RabbitMQ image tag -  backporting to pre 4.x.x version of rabbitmq
+    tag: 3.11.18-debian-11-r0
+    ## @param rabbitmq.image.pullPolicy The RabbitMQ image pull policy
+    pullPolicy: IfNotPresent
+
 ## @section Solr Bitnami Sub-Chart Configuration
 ##
 solr:


### PR DESCRIPTION
### Summary
This pull request addresses **issue #198**, which concerns a mismatch in Bitnami chart dependencies used in the Helm chart for the `dataone-indexer` subsystem. The changes ensure compatibility with the latest supported versions of RabbitMQ and Solr charts.

---

### Problem
The existing Helm chart dependencies for `bitnami/common` chart for RabbitMQ (v11.16.2) and Solr (v9.5.5) were outdated and not aligned with the latest features and fixes available in their respective upstream Bitnami charts. Additionally, there was a need to backport the RabbitMQ image to a pre-4.x.x version for compatibility purposes.

---

### Solution
The following changes were made to resolve the issue:
1. **Updated RabbitMQ chart version**:
   - Upgraded from `v11.16.2` to `v15.5.3`.
   - Added configuration for the RabbitMQ container image to explicitly use the `3.11.18-debian-11-r0` tag to ensure compatibility with pre-4.x.x versions.

2. **Updated Solr chart version**:
   - Upgraded from `v9.5.5` to `v9.6.1`.

3. **Chart metadata updates**:
   - Updated the `Chart.lock` file to reflect the new dependency versions and their associated digests.
   - Incremented the Helm chart version from `1.2.0` to `1.2.1` in `Chart.yaml`.

4. **Introduced image configuration for RabbitMQ**:
   - Added the `image.repository`, `image.tag`, and `image.pullPolicy` fields in the `values.yaml` file for RabbitMQ.

---

### Testing
- Verified Helm chart installation with the upgraded dependencies.
- Confirmed that the RabbitMQ and Solr services initialize correctly with the updated configurations.
- Validated the backported RabbitMQ image for compatibility with the application.

---

### Impact
- This update ensures that the Helm chart is aligned with the latest supported versions of RabbitMQ and Solr, providing better stability and access to upstream fixes.
- The backporting of RabbitMQ ensures compatibility with the existing application requirements, avoiding potential disruptions.

---

### References
Fixes #198  
For more details, see the [comparison view of the changes](https://github.com/DataONEorg/dataone-indexer/compare/main...ess-dive:dataone-indexer:issue-198-bitnami-common-chart-mismatch?expand=1).  
