### PR TITLE
Upgrade the log4j-layout-template-json version to 2.24.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-layout-template-json</artifactId>
-            <version>2.17.2</version>
+            <version>${log4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.solr</groupId>


### PR DESCRIPTION
First round of merge:

Upgraded the version of log4j-layout-template-json to 2.24.3.