### PR TITLE
Enhance Helm Chart: Support Extra Volumes, Storage Options, Security Contexts, and HPC Filesystem Warmup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ ARG TAG="NO-TAG"
 ENV TAG=${TAG}
 ENV DATAONE_INDEXER_CONFIG=/etc/dataone/dataone-indexer.properties
 
-# Set the working directory 
+# Set the working directory
 WORKDIR /var/lib/dataone-indexer
 
 RUN apt update && apt -y install \

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -191,6 +191,9 @@ spec:
             readOnly: true
           {{- end }}
         - name: {{ .Release.Name }}-temp-tripledb-volume
+          {{- if .Values.idxworker.tripleDbStorageDefinition }}
+          {{- tpl (toYaml .Values.idxworker.tripleDbStorageDefinition) . | nindent 10 }}
+          {{- else }}
           ephemeral:
             volumeClaimTemplate:
               spec:
@@ -201,3 +204,4 @@ spec:
                 resources:
                   requests:
                     storage: 1Gi
+         {{- end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -47,8 +47,10 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.securityContext }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.idxworker.readinessProbe.enabled }}
@@ -119,6 +121,10 @@ spec:
       initContainers:
         - name: dependencies
           image: busybox:latest
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           command:
             - sh
             - -c

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -74,6 +74,9 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
+            {{- if .Values.extraVolumeMounts }}
+            {{- tpl (toYaml .Values.extraVolumeMounts) . | nindent 12 }}
+            {{- end }}
             - mountPath: /etc/dataone/dataone-indexer.properties
               subPath: dataone-indexer.properties
               name: {{ .Release.Name }}-config-volume
@@ -144,6 +147,9 @@ spec:
               echo waiting for Solr Schema to be accessible at http://{{ $solrHost }}:
               {{- $solrPort }}$SOLRURI; sleep 1; done;
       volumes:
+        {{- if .Values.extraVolumes }}
+        {{- tpl (toYaml .Values.extraVolumes) . | nindent 8 }}
+        {{- end }}
         - name: {{ .Release.Name }}-config-volume
           configMap:
             name: {{ .Release.Name }}-indexer-configfiles

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
       {{- end }}
       labels:
         {{- include "idxworker.selectorLabels" . | nindent 8 }}
+      namespace: {{ .Release.Namespace }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -47,6 +48,25 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
+        {{- if .Values.idxworker.enableMountWarmupHook }}
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - sh
+                  - -c
+                  - |
+                    {
+                      ## This is a workaround for the Lustre file system
+                      echo "$(date '+%Y-%m-%d %H:%M:%S.%3N') - Warming up mounted directories..." >> /tmp/postStart.log
+                      ls -1 /var/metacat/hashstore/metadata/tmp > /dev/null 2>&1 || true
+                      ls -1 /var/metacat/hashstore/refs/tmp > /dev/null 2>&1 || true
+                      ls -1 /var/metacat/hashstore/objects > /dev/null 2>&1 || true
+                      ls -1 /var/metacat/hashstore/refs/pids > /dev/null 2>&1 || true
+                      ls -1 /var/metacat/hashstore/refs/cids > /dev/null 2>&1 || true
+                      echo "$(date '+%Y-%m-%d %H:%M:%S.%3N') - Warm-up complete." >> /tmp/postStart.log
+                    }
+        {{- end }}
           {{- if .Values.securityContext }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -209,6 +209,10 @@ idxworker:
   ##
   tripleDbDirectory: /etc/dataone/tdb-cache
 
+  ## @param idxworker.tripleDbStorageDefinition type of storage for the triple store (default is "ephemeral"). Other
+  ## options  are "hostPath" and "emptyDir".  Must give full definition for hostPath or emptyDir.
+  tripleDbStorageDefinition: {}
+
   ## @param idxworker.enableMountWarmupHook Enable or disable the mount warmup hook.  This is a workaround for
   ## specifically Lustre filesystems. This workaround addresses known behavior with Lustre and other HPC
   ## file systems that require access within the container runtime to finalize mount visibility.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -75,6 +75,7 @@ podAnnotations: {}
 podSecurityContext:
   fsGroup: 1000 # must match metacat group for shared volume at /var/metacat
 
+## @param securityContext Security context for the container (This will be applied to all containers)
 securityContext:
   runAsNonRoot: true
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -106,6 +106,11 @@ tolerations: []
 
 affinity: {}
 
+## @param extraVolumes Additional volumes to be added to the pod
+extraVolumes: []
+## @param extraVolumeMounts Additional volume mounts to be added to the pod
+extraVolumeMounts: []
+
 persistence:
   ## @param persistence.claimName Name of existing PVC to use (typically shared with metacat)
   ## Set a value for 'claimName' only if you want to re-use a Persistent Volume Claim that has

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -209,6 +209,11 @@ idxworker:
   ##
   tripleDbDirectory: /etc/dataone/tdb-cache
 
+  ## @param idxworker.enableMountWarmupHook Enable or disable the mount warmup hook.  This is a workaround for
+  ## specifically Lustre filesystems. This workaround addresses known behavior with Lustre and other HPC
+  ## file systems that require access within the container runtime to finalize mount visibility.
+  enableMountWarmupHook: false
+
   storage:
     hashStoreClassName: "org.dataone.hashstore.filehashstore.FileHashStore"
     hashStoreRootDir: "/var/metacat/hashstore"


### PR DESCRIPTION
## Summary

This pull request introduces several enhancements to the `dataone-indexer` Helm chart and Dockerfile to improve deployment flexibility, security, and compatibility with specialized storage and HPC environments.

## Major Features & Changes

### 1. Support for Extra Volumes and Volume Mounts ([c487c66])
- **Feature:** Users can now define additional volumes and volume mounts via `extraVolumes` and `extraVolumeMounts` in `values.yaml`.
- **Implementation:** 
  - `deployment.yaml` updated to conditionally render extra volumes/mounts using `tpl`.
  - New parameters added to `values.yaml`.
- **Benefit:** Enables more complex deployment scenarios and custom storage requirements.
- **Closes:** #223

### 2. Improved User and Security Context Configuration ([1fa1f8a])
- **Feature:** Conditional support for configuring `securityContext` for both containers and `initContainers`.
- **Implementation:** 
  - `securityContext` parameter introduced in `values.yaml`.
  - `deployment.yaml` updated for conditional rendering based on provided settings.
- **Benefit:** Improves security posture and allows deployments to better conform to cluster policies.
- **Closes:** #224

### 3. Optional Mount Warmup Hook for Lustre/HPC Filesystems ([b05eb3b])
- **Feature:** Optional lifecycle `postStart` hook to warm up mounts, resolving visibility issues with Lustre and similar HPC filesystems.
- **Implementation:**
  - `idxworker.enableMountWarmupHook` added to `values.yaml`.
  - Deployment sets namespace explicitly in pod metadata.
- **Benefit:** Ensures reliable access to mounted directories on HPC/Lustre systems.
- **Closes:** #227

### 4. Alternate Storage Definition for tripleDB ([be5657d])
- **Feature:** Allows custom storage configuration for the `tripleDB` volume.
- **Implementation:** 
  - Added `idxworker.tripleDbStorageDefinition` to `values.yaml`.
  - `deployment.yaml` uses custom storage if provided, defaults to ephemeral otherwise.
  - Supports `hostPath` and `emptyDir` as alternatives.
- **Benefit:** Greater flexibility for storage provisioning, especially in environments requiring persistent or special storage types.
- **Closes:** #228

## Related Issues
- #223: Support extra volumes and mounts in deployment
- #224: Improve user and security context configurations
- #227: Add optional mount warmup hook for Lustre/HPC filesystems
- #228: Allow alternate storage definition for tripleDB

## Testing

- Verified deployment with various volume and mount configurations.
- Tested security context settings on containers and initContainers.
- Confirmed correct execution of mount warmup hook on clusters with HPC/Lustre filesystems.
- Validated custom storage definitions for tripleDB.

## Checklist

- [x] Helm chart renders successfully with default and custom values.
- [x] Features tested on minikube and HPC cluster.
- [x] Documentation in `values.yaml` updated for new parameters.
- [x] All referenced issues are closed.
