### PR TITLE
Added the archived field to the dummy solr doc.

### DIFF
--- a/src/main/java/org/dataone/cn/indexer/solrhttp/DummySolrDoc.java
+++ b/src/main/java/org/dataone/cn/indexer/solrhttp/DummySolrDoc.java
@@ -44,6 +44,7 @@ public class DummySolrDoc extends SolrDoc {
         }
         // the indication field (isPlaceholder_b)
         addField(new SolrElementField(INDICATION_FIELD, INDICATION_VALUE));
+        addField(new SolrElementField("archived", "false"));
     }
 
     /**

--- a/src/test/java/org/dataone/cn/indexer/parser/utility/RelationshipMergeUtilityTest.java
+++ b/src/test/java/org/dataone/cn/indexer/parser/utility/RelationshipMergeUtilityTest.java
@@ -125,7 +125,7 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
         // doc is null, but dummy is not
         dummyDoc = new DummySolrDoc(id, null);
         newDoc = mergeUtility.mergeRelationships(dummyDoc, doc);
-        assertEquals(3, newDoc.getFieldList().size());
+        assertEquals(4, newDoc.getFieldList().size());
         assertEquals(id, newDoc.getFirstFieldValue(SolrElementField.FIELD_ID));
         assertEquals("-1", newDoc.getFirstFieldValue(SolrElementField.FIELD_VERSION));
         // dummy is null, but doc is not

--- a/src/test/java/org/dataone/cn/indexer/solrhttp/DummySolrDocTest.java
+++ b/src/test/java/org/dataone/cn/indexer/solrhttp/DummySolrDocTest.java
@@ -1,6 +1,7 @@
 package org.dataone.cn.indexer.solrhttp;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -42,10 +43,11 @@ public class DummySolrDocTest {
         assertTrue(e.getMessage().contains(SolrElementField.FIELD_ID));
 
         doc = new DummySolrDoc(pid1, null);
-        assertEquals(3, doc.getFieldList().size());
+        assertEquals(4, doc.getFieldList().size());
         assertEquals("-1", doc.getField(SolrElementField.FIELD_VERSION).getValue());
         assertEquals(pid1, doc.getField(SolrElementField.FIELD_ID).getValue());
         assertTrue(Boolean.parseBoolean(doc.getField(INDICATION_FIELD_NAME).getValue()));
+        assertFalse(Boolean.parseBoolean(doc.getField("archived").getValue()));
 
 
         doc = new DummySolrDoc(pid, accessDoc);
@@ -70,6 +72,7 @@ public class DummySolrDocTest {
         assertEquals(user2, doc.getAllFieldValues(SolrElementField.FIELD_WRITEPERMISSION).get(1));
         assertNull(doc.getField(SolrElementField.FIELD_CHANGEPERMISSION));
         assertEquals(resourceMapId, doc.getField(SolrElementField.FIELD_RESOURCEMAP).getValue());
+        assertFalse(Boolean.parseBoolean(doc.getField("archived").getValue()));
     }
 
     /**


### PR DESCRIPTION
Based on the request from MetacatUI, the `archived` field is added to the dummy solr doc.