### PR TITLE
Make liveness/readiness probe parameters configurable in Helm chart

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -78,25 +78,13 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.idxworker.readinessProbe.enabled }}
+          {{- if .Values.idxworker.livenessProbe.enabled }}
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - test $(($(date +%s) - $(stat -c %Y /var/lib/dataone-indexer/livenessprobe))) -lt 20
-            initialDelaySeconds: 20
-            periodSeconds: 15
+            {{- omit .Values.idxworker.livenessProbe "enabled" | toYaml | nindent 12 }}
           {{- end }}
           {{- if .Values.idxworker.readinessProbe.enabled }}
           readinessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - test $(($(date +%s) - $(stat -c %Y /var/lib/dataone-indexer/readinessprobe))) -lt 40
-            initialDelaySeconds: 20
-            periodSeconds: 35
+            {{- omit .Values.idxworker.readinessProbe "enabled" | toYaml | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -249,12 +249,30 @@ idxworker:
     hashStoreDirWidth: 2
     hashStoreDirDepth: 3
 
-  ## @param idxworker.livenessProbe.enabled Enable or disable default probe (see deployment.yaml)
   livenessProbe:
+    ## @param idxworker.livenessProbe.enabled Enable or disable probe
     enabled: true
-  ## @param idxworker.readinessProbe.enabled Enable or disable default probe (see deployment.yaml)
+    # Default exec command (may be overridden)
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - test $(($(date +%s) - $(stat -c %Y /var/lib/dataone-indexer/livenessprobe))) -lt 20
+    initialDelaySeconds: 20
+    periodSeconds: 15
+
+
   readinessProbe:
+    ## @param idxworker.readinessProbe.enabled Enable or disable probe
     enabled: true
+    # Default exec command (may be overridden)
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - test $(($(date +%s) - $(stat -c %Y /var/lib/dataone-indexer/readinessprobe))) -lt 40
+    initialDelaySeconds: 20
+    periodSeconds: 35
 
   ## @param idxworker.javaMem Java memory options to pass to the index worker container
   ## (format: "-Xms512m -Xmx2g"). If you do not set a value, the JVM will default to using 1/4 of


### PR DESCRIPTION
Make liveness/readiness probe parameters configurable in Helm chart; see #285 