### PR TITLE
fix: Enable conditional deployment of RabbitMQ cluster based on conf

### DIFF
--- a/helm/templates/rabbitmq.yaml
+++ b/helm/templates/rabbitmq.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rabbitmq.enabled }}
 ### RabbitMQ Cluster Configuration
 ## --------------------------------------
 ## This manifest deploys a RabbitMQ cluster using the RabbitMQ Cluster Operator.
@@ -32,3 +33,4 @@ spec:
   persistence:
     storageClassName: {{ .Values.rabbitmq.persistence.storageClassName }}
     storage: {{ .Values.rabbitmq.persistence.size }}
+{{- end }}


### PR DESCRIPTION
Make RabbitMQ deployment optional

**Changes**

- Wrapped the RabbitMQ cluster configuration in rabbitmq.yaml with a conditional check based on `.Values.rabbitmq.enabled`

**Purpose**

- Allows RabbitMQ to be optionally deployed as part of the Helm chart. When rabbitmq.enabled is set to false, the RabbitMQ cluster resource will not be created, enabling use of an external RabbitMQ instance or disabling the feature entirely.

**Impact**

- Non-breaking: Existing deployments will continue to work if rabbitmq.enabled defaults to true in values.yaml
- Provides flexibility for different deployment scenarios (development, production, external services)
- Reduces resource footprint when RabbitMQ is not needed or managed externally

**Testing**

- Verify deployment works with rabbitmq.enabled: true (default behavior)
- Verify RabbitMQ resources are not created when rabbitmq.enabled: false

Closes #308