### PR TITLE
Revert "fix: Enable conditional deployment of RabbitMQ cluster based on conf"

### DIFF
--- a/helm/templates/rabbitmq.yaml
+++ b/helm/templates/rabbitmq.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.rabbitmq.enabled }}
 ### RabbitMQ Cluster Configuration
 ## --------------------------------------
 ## This manifest deploys a RabbitMQ cluster using the RabbitMQ Cluster Operator.
@@ -33,4 +32,3 @@ spec:
   persistence:
     storageClassName: {{ .Values.rabbitmq.persistence.storageClassName }}
     storage: {{ .Values.rabbitmq.persistence.size }}
-{{- end }}


### PR DESCRIPTION
Reverts DataONEorg/dataone-indexer#309

We are reverting because the original PR should have been merged to `develop` instead of to `main`. Once this is reverted, we will create a similar PR to merge the changes to `develop`