### PR TITLE
Issue/308 config disable rabbitmq operator

### DIFF
--- a/helm/templates/rabbitmq.yaml
+++ b/helm/templates/rabbitmq.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rabbitmq.enabled }}
 ### RabbitMQ Cluster Configuration
 ## --------------------------------------
 ## This manifest deploys a RabbitMQ cluster using the RabbitMQ Cluster Operator.
@@ -32,3 +33,4 @@ spec:
   persistence:
     storageClassName: {{ .Values.rabbitmq.persistence.storageClassName }}
     storage: {{ .Values.rabbitmq.persistence.size }}
+{{- end }}


### PR DESCRIPTION
> [!NOTE]
>
> The original PR #309 was inadvertently opened against and merged to `main` instead of `develop`. It has therefore been reverted (see PR #321), and this PR is now being opened to merge the code changes to `develop` instead.

---
---

[vchendrix](https://github.com/vchendrix) commented [3 weeks ago](https://github.com/DataONEorg/dataone-indexer/compare/develop...ess-dive:dataone-indexer:issue/308-config-disable-rabbitmq-operator#issue-3819287874)

Make RabbitMQ deployment optional

**Changes**

- Wrapped the RabbitMQ cluster configuration in rabbitmq.yaml with a conditional check based on `.Values.rabbitmq.enabled`

**Purpose**

- Allows RabbitMQ to be optionally deployed as part of the Helm chart. When rabbitmq.enabled is set to false, the RabbitMQ cluster resource will not be created, enabling use of an external RabbitMQ instance or disabling the feature entirely.

**Impact**

- Non-breaking: Existing deployments will continue to work if rabbitmq.enabled defaults to true in values.yaml
- Provides flexibility for different deployment scenarios (development, production, external services)
- Reduces resource footprint when RabbitMQ is not needed or managed externally

**Testing**

- Verify deployment works with rabbitmq.enabled: true (default behavior)
- Verify RabbitMQ resources are not created when rabbitmq.enabled: false

Closes #308