### PR TITLE
Adding filter to exclude a case where multiple `SO:datePublished` values are returned 

### DIFF
--- a/src/main/resources/application-context-schema-org.xml
+++ b/src/main/resources/application-context-schema-org.xml
@@ -183,6 +183,7 @@
                         ?datasetId SO:datePublished ?datePublished
                         # Don't include referenced sub-Datasets (i.e. a Dataset in a 'hasPart' property)
                         FILTER NOT EXISTS { ?id SO:hasPart ?datasetId . }
+                        FILTER NOT EXISTS { ?id SO:workExample ?datasetId . }
                     }
                 ]]>
             </value>

--- a/src/main/resources/application-context-schema-org.xml
+++ b/src/main/resources/application-context-schema-org.xml
@@ -181,9 +181,11 @@
                     WHERE {
                         ?datasetId rdf:type SO:Dataset .
                         ?datasetId SO:datePublished ?datePublished
-                        # Don't include referenced sub-Datasets (i.e. a Dataset in a 'hasPart' property)
-                        FILTER NOT EXISTS { ?id SO:hasPart ?datasetId . }
-                        FILTER NOT EXISTS { ?id SO:workExample ?datasetId . }
+                        # Filter out any dataset that is a child of another dataset
+                        FILTER NOT EXISTS {
+                            ?parentDataset rdf:type SO:Dataset .
+                            ?parentDataset ?p ?datasetId . 
+                        }
                     }
                 ]]>
             </value>


### PR DESCRIPTION
This is a fix described and proposed in #332, where a SparQL query is modified to add a filter excluding `datePublished` values being returned from `workExample` nodes, which then prevents indexing.