### PR TITLE
upgrade docker base image to Java 25 & Ubuntu Resolute

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,6 @@
 # Build from parent dir with a command like:
 #     `nerdctl build -t dataone-index-worker:2.4.0 -f docker/Dockerfile --build-arg TAG=2.4.0 .`
-# Use an OpenJDK runtime as a parent image
-FROM eclipse-temurin:17.0.17_10-jre-noble
+FROM eclipse-temurin:25.0.3_9-jre-resolute
 
 ARG TAG="NO-TAG"
 ENV TAG=${TAG}


### PR DESCRIPTION
This is a small step towards building and running the indexer with Java 25 (see #304)

The indexer code is still currently built with Java 17, but it runs fine in a Java 25 JVM, and the tests all pass. The change in this PR is therefore to run the code in a Java 25 container in k8s.