### PR TITLE
Upgrade java to 25

### DIFF
--- a/.github/workflows/build-test-publish.yaml
+++ b/.github/workflows/build-test-publish.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           cache: 'maven'
       - name: Extract Maven project version

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <url>http://maven.apache.org</url>
 
     <properties>
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.version>5.3.39</spring.version>
         <d1_libclient_java.version>2.3.1</d1_libclient_java.version>

--- a/src/main/resources/index-parser-context.xml
+++ b/src/main/resources/index-parser-context.xml
@@ -106,118 +106,120 @@
          <constructor-arg name="namespaceList">
           <list>
                <bean class="org.dataone.cn.indexer.XMLNamespace">
-                <constructor-arg name="namespace" value="http://ns.dataone.org/service/types/v2.0" />
-                <constructor-arg name="prefix" value="d200" />
+                   <constructor-arg name="prefix" value="d200" />
+                   <constructor-arg name="namespace"
+                                  value="http://ns.dataone.org/service/types/v2.0" />
                </bean>
                <bean class="org.dataone.cn.indexer.XMLNamespace">
-                <constructor-arg name="namespace" value="eml://ecoinformatics.org/eml-2.0.0" />
-                <constructor-arg name="prefix" value="eml200" />
+                   <constructor-arg name="prefix" value="eml200" />
+                   <constructor-arg name="namespace" value="eml://ecoinformatics.org/eml-2.0.0" />
                </bean>
                <bean class="org.dataone.cn.indexer.XMLNamespace">
-                <constructor-arg name="namespace" value="eml://ecoinformatics.org/eml-2.0.1" />
-                <constructor-arg name="prefix" value="eml201" />
+                   <constructor-arg name="prefix" value="eml201" />
+                   <constructor-arg name="namespace" value="eml://ecoinformatics.org/eml-2.0.1" />
                </bean>
                <bean class="org.dataone.cn.indexer.XMLNamespace">
+                   <constructor-arg name="prefix" value="eml210" />
                 <constructor-arg name="namespace" value="eml://ecoinformatics.org/eml-2.1.0" />
-                <constructor-arg name="prefix" value="eml210" />
                </bean>
-           <bean class="org.dataone.cn.indexer.XMLNamespace">
-                <constructor-arg name="namespace" value="eml://ecoinformatics.org/eml-2.1.1" />
-                <constructor-arg name="prefix" value="eml211" />
-             </bean>
-             <bean class="org.dataone.cn.indexer.XMLNamespace">
-                <constructor-arg name="namespace" value="https://eml.ecoinformatics.org/eml-2.2.0" />
-                <constructor-arg name="prefix" value="eml220" />
-         </bean>
-           <bean class="org.dataone.cn.indexer.XMLNamespace">
-                <constructor-arg name="prefix" value="cito" />
-                <constructor-arg name="namespace" value="http://purl.org/spar/cito/" />
-           </bean>
-           <bean class="org.dataone.cn.indexer.XMLNamespace">
+                <bean class="org.dataone.cn.indexer.XMLNamespace">
+                   <constructor-arg name="prefix" value="eml211" />
+                    <constructor-arg name="namespace" value="eml://ecoinformatics.org/eml-2.1.1" />
+                 </bean>
+                 <bean class="org.dataone.cn.indexer.XMLNamespace">
+                     <constructor-arg name="prefix" value="eml220" />
+                     <constructor-arg name="namespace"
+                                      value="https://eml.ecoinformatics.org/eml-2.2.0" />
+                 </bean>
+               <bean class="org.dataone.cn.indexer.XMLNamespace">
+                    <constructor-arg name="prefix" value="cito" />
+                    <constructor-arg name="namespace" value="http://purl.org/spar/cito/" />
+               </bean>
+               <bean class="org.dataone.cn.indexer.XMLNamespace">
                     <constructor-arg name="prefix" value="dc" />
-                <constructor-arg name="namespace" value="http://purl.org/dc/elements/1.1/" />
-           </bean>
-           <bean class="org.dataone.cn.indexer.XMLNamespace">
-                <constructor-arg name="prefix" value="dcterms" />
-                <constructor-arg name="namespace" value="http://purl.org/dc/terms/" />
-           </bean>
-           <bean class="org.dataone.cn.indexer.XMLNamespace">
-                <constructor-arg name="prefix" value="dwc" />
-                <constructor-arg name="namespace" value="http://rs.tdwg.org/dwc/terms/" />
-           </bean>
-           <bean class="org.dataone.cn.indexer.XMLNamespace">
-                <constructor-arg name="prefix" value="foaf" />
-                <constructor-arg name="namespace" value="http://xmlns.com/foaf/0.1/" />
-           </bean>
-           <bean class="org.dataone.cn.indexer.XMLNamespace">
-                <constructor-arg name="prefix" value="ore" />
-                <constructor-arg name="namespace" value="http://www.openarchives.org/ore/terms/" />
-           </bean>
-           <bean class="org.dataone.cn.indexer.XMLNamespace">
-                <constructor-arg name="prefix" value="rdf" />
-                <constructor-arg name="namespace" value="http://www.w3.org/1999/02/22-rdf-syntax-ns#" />
-           </bean>
-           <bean class="org.dataone.cn.indexer.XMLNamespace">
+                    <constructor-arg name="namespace" value="http://purl.org/dc/elements/1.1/" />
+               </bean>
+               <bean class="org.dataone.cn.indexer.XMLNamespace">
+                    <constructor-arg name="prefix" value="dcterms" />
+                    <constructor-arg name="namespace" value="http://purl.org/dc/terms/" />
+               </bean>
+               <bean class="org.dataone.cn.indexer.XMLNamespace">
+                    <constructor-arg name="prefix" value="dwc" />
+                    <constructor-arg name="namespace" value="http://rs.tdwg.org/dwc/terms/" />
+               </bean>
+               <bean class="org.dataone.cn.indexer.XMLNamespace">
+                    <constructor-arg name="prefix" value="foaf" />
+                    <constructor-arg name="namespace" value="http://xmlns.com/foaf/0.1/" />
+               </bean>
+               <bean class="org.dataone.cn.indexer.XMLNamespace">
+                    <constructor-arg name="prefix" value="ore" />
+                    <constructor-arg name="namespace" value="http://www.openarchives.org/ore/terms/" />
+               </bean>
+               <bean class="org.dataone.cn.indexer.XMLNamespace">
+                    <constructor-arg name="prefix" value="rdf" />
+                    <constructor-arg name="namespace" value="http://www.w3.org/1999/02/22-rdf-syntax-ns#" />
+               </bean>
+               <bean class="org.dataone.cn.indexer.XMLNamespace">
                    <constructor-arg name="prefix" value="rdfs1" />
                    <constructor-arg name="namespace" value="http://www.w3.org/2001/01/rdf-schema#" />
-           </bean>
-           <bean class="org.dataone.cn.indexer.XMLNamespace">
+               </bean>
+               <bean class="org.dataone.cn.indexer.XMLNamespace">
                    <constructor-arg name="prefix" value="bibo" />
                    <constructor-arg name="namespace" value="http://purl.org/ontology/bibo/" />
-           </bean>
-           <bean class="org.dataone.cn.indexer.XMLNamespace">
-                      <constructor-arg name="prefix" value="dryad" />
+               </bean>
+               <bean class="org.dataone.cn.indexer.XMLNamespace">
+                   <constructor-arg name="prefix" value="dryad" />
                    <constructor-arg name="namespace" value="http://purl.org/dryad/terms/" />
-              </bean>
-              <bean class="org.dataone.cn.indexer.XMLNamespace">
-                      <constructor-arg name="prefix" value="datacite" />
+               </bean>
+               <bean class="org.dataone.cn.indexer.XMLNamespace">
+                   <constructor-arg name="prefix" value="datacite" />
                    <constructor-arg name="namespace" value="http://datacite.org/schema/kernel-3" />
-              </bean>
-              <bean class="org.dataone.cn.indexer.XMLNamespace">
+               </bean>
+               <bean class="org.dataone.cn.indexer.XMLNamespace">
                    <constructor-arg name="prefix" value="xsi" />
                    <constructor-arg name="namespace" value="http://www.w3.org/2001/XMLSchema-instance" />
-              </bean>
-              <bean class="org.dataone.cn.indexer.XMLNamespace">
-                      <constructor-arg name="prefix" value="gmd" />
-                      <constructor-arg name="namespace" value="http://www.isotc211.org/2005/gmd" />
-              </bean>
+               </bean>
+               <bean class="org.dataone.cn.indexer.XMLNamespace">
+                   <constructor-arg name="prefix" value="gmd" />
+                   <constructor-arg name="namespace" value="http://www.isotc211.org/2005/gmd" />
+               </bean>
 
-            <bean class="org.dataone.cn.indexer.XMLNamespace">
-                 <constructor-arg name="prefix" value="gco" />
+                <bean class="org.dataone.cn.indexer.XMLNamespace">
+                    <constructor-arg name="prefix" value="gco" />
                     <constructor-arg name="namespace" value="http://www.isotc211.org/2005/gco" />
-            </bean>
+                </bean>
 
-            <bean class="org.dataone.cn.indexer.XMLNamespace">
-                 <constructor-arg name="prefix" value="gmx" />
+                <bean class="org.dataone.cn.indexer.XMLNamespace">
+                    <constructor-arg name="prefix" value="gmx" />
                     <constructor-arg name="namespace" value="http://www.isotc211.org/2005/gmx" />
-            </bean>
+                </bean>
 
-            <bean class="org.dataone.cn.indexer.XMLNamespace">
-                 <constructor-arg name="prefix" value="gml" />
+                <bean class="org.dataone.cn.indexer.XMLNamespace">
+                    <constructor-arg name="prefix" value="gml" />
                     <constructor-arg name="namespace" value="http://www.opengis.net/gml/3.2" />
-            </bean>
+                </bean>
 
-            <bean class="org.dataone.cn.indexer.XMLNamespace">
-                 <constructor-arg name="prefix" value="srv" />
+                <bean class="org.dataone.cn.indexer.XMLNamespace">
+                    <constructor-arg name="prefix" value="srv" />
                     <constructor-arg name="namespace" value="http://www.isotc211.org/2005/srv" />
-            </bean>
+                </bean>
 
-            <bean class="org.dataone.cn.indexer.XMLNamespace">
-                 <constructor-arg name="prefix" value="xlink" />
+                <bean class="org.dataone.cn.indexer.XMLNamespace">
+                    <constructor-arg name="prefix" value="xlink" />
                     <constructor-arg name="namespace" value="http://www.w3.org/1999/xlink" />
-            </bean>
+                </bean>
 
-            <bean class="org.dataone.cn.indexer.XMLNamespace">
-                <constructor-arg name="prefix" value="portals100" />
-                <constructor-arg name="namespace" value="https://purl.dataone.org/portals-1.0.0" />
-            </bean>
+                <bean class="org.dataone.cn.indexer.XMLNamespace">
+                    <constructor-arg name="prefix" value="portals100" />
+                    <constructor-arg name="namespace" value="https://purl.dataone.org/portals-1.0.0" />
+                </bean>
 
-            <bean class="org.dataone.cn.indexer.XMLNamespace">
-                <constructor-arg name="prefix" value="collections100" />
-                <constructor-arg name="namespace" value="https://purl.dataone.org/collections-1.0.0" />
-            </bean>
+                <bean class="org.dataone.cn.indexer.XMLNamespace">
+                    <constructor-arg name="prefix" value="collections100" />
+                    <constructor-arg name="namespace" value="https://purl.dataone.org/collections-1.0.0" />
+                </bean>
 
-        </list>
+            </list>
          </constructor-arg>
     </bean>
 


### PR DESCRIPTION
The ticket is [here](https://github.com/DataONEorg/dataone-indexer/issues/304).
The most changes are format changes in `xml-parser-context.xml`. The real changes is the order change on the first six beans. 